### PR TITLE
chore: add Claude Code configuration and docs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pip install -r requirements.txt)",
+      "Bash(pip list)",
+      "Bash(python --version)",
+      "Bash(ls *)",
+      "Bash(cat requirements.txt)"
+    ],
+    "deny": [
+      "Bash(python timesheet.py*)",
+      "Edit(config.py)",
+      "Write(config.py)",
+      "Edit(data/*)",
+      "Write(data/*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,21 @@ CLI tool to export Toggl time entries to CSV timesheets. Fetches time tracking d
 - `python timesheet.py -f` - Export all entries to full.csv
 - `python timesheet.py -h` - Show help
 
-### Development
+### Development Setup (using virtualenv - recommended)
+```bash
+# Create and activate virtual environment
+python -m virtualenv venv
+source venv/bin/activate  # Linux/Mac
+# venv\Scripts\activate   # Windows
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### Quick Commands
 - `pip install -r requirements.txt` - Install dependencies
+- `source venv/bin/activate` - Activate virtual environment
+- `deactivate` - Deactivate virtual environment
 
 ### Dangerous Commands (DO NOT run without explicit permission)
 - `python timesheet.py` - Calls Toggl API (uses API quota)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+## Project Overview
+
+CLI tool to export Toggl time entries to CSV timesheets. Fetches time tracking data from the Toggl API and generates formatted CSV reports organized by client and project.
+
+**Tech Stack:** Python 2.7 (legacy, planning upgrade to Python 3)
+**Dependencies:** requests, dataset, SQLAlchemy, python-dateutil
+
+## Commands
+
+### Running the Tool
+- `python timesheet.py` - Generate timesheet CSV for last month
+- `python timesheet.py -s 2024-01-01 -e 2024-01-31` - Custom date range
+- `python timesheet.py -p` - Generate per-project CSVs
+- `python timesheet.py -f` - Export all entries to full.csv
+- `python timesheet.py -h` - Show help
+
+### Development
+- `pip install -r requirements.txt` - Install dependencies
+
+### Dangerous Commands (DO NOT run without explicit permission)
+- `python timesheet.py` - Calls Toggl API (uses API quota)
+- Any modifications to `config.py` - Contains API credentials
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     toggl_timesheet                              │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│    ┌──────────────────┐                                         │
+│    │   timesheet.py   │  CLI Entry Point                        │
+│    │   (main)         │  - Parse args, orchestrate flow         │
+│    └────────┬─────────┘                                         │
+│             │                                                    │
+│    ┌────────┴─────────┐                                         │
+│    ▼                  ▼                                         │
+│  ┌──────────────┐  ┌──────────────┐                             │
+│  │  togglapi/   │  │  toggltime/  │                             │
+│  │  api.py      │  │  toggltime.py│                             │
+│  │              │  │  timelib.py  │                             │
+│  │ - TogglAPI   │  │              │                             │
+│  │ - ReportAPI  │  │ - Toggletime │                             │
+│  └──────┬───────┘  │ - Time utils │                             │
+│         │          └──────┬───────┘                             │
+│         │                 │                                      │
+│         ▼                 ▼                                      │
+│  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐           │
+│  │ Toggl API   │   │  SQLite DB  │   │  CSV Files  │           │
+│  │ (external)  │   │  (data/*.db)│   │ (data/*.csv)│           │
+│  └─────────────┘   └─────────────┘   └─────────────┘           │
+│                                                                  │
+│  Config: config.py (API token, workspace ID, timezone)          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Modules
+
+- **timesheet.py** - Main CLI, argument parsing, CSV generation
+- **togglapi/api.py** - `TogglAPI` (time entries), `ReportAPI` (detailed reports)
+- **toggltime/toggltime.py** - `Toggletime` class for time entry manipulation
+- **toggltime/timelib.py** - Date/time utility functions
+- **config.py** - User configuration (API token, workspace ID, timezone)
+
+## Conventions
+
+### Code Style
+- Maintain Python 2.7 compatibility while preparing for Python 3 migration
+- Use `from __future__ import` for forward compatibility
+- Follow existing patterns in codebase
+
+### Commit Messages
+Use Conventional Commits format:
+- `feat:` new features
+- `fix:` bug fixes
+- `chore:` maintenance tasks
+- `docs:` documentation changes
+- `refactor:` code refactoring
+
+## Protected Files
+
+**DO NOT modify without explicit permission:**
+- `config.py` - Contains API credentials
+- `data/` directory - Output files, user data
+
+## Notes
+
+- The codebase uses Python 2.7 print statements and urllib
+- Migration to Python 3 is planned
+- Virtual environments: `venv-tt/` (old), `venv-tt-new/` (newer)

--- a/README.md
+++ b/README.md
@@ -12,12 +12,21 @@ Installation on linux
 If you are using linux, you most probably have Python already installed on your machine.
 If not, use your distro's package management system to install Python 2.7
 
-* Downloading the source code from [here](https://github.com/epablosensei/toggl_timesheet/archive/master.zip)
-* navaigate to the directory and run the following command to install the required packages :
+* Download the source code from [here](https://github.com/epablosensei/toggl_timesheet/archive/master.zip)
+* Navigate to the directory and create a virtual environment (recommended):
 
+```bash
+# Create virtual environment
+python -m virtualenv venv
+
+# Activate virtual environment
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
 ```
-$ pip install -r requirements.txt
-```
+
+> **Note:** Using a virtual environment keeps dependencies isolated and prevents conflicts with system packages. Always activate the venv before running the tool.
 
 * Copy `config.py-example` to `config.py`
 * In `config.py` 
@@ -32,13 +41,23 @@ Installation on Windows
 * If you don't have Python installed, then you must install Python 2.7 from [here](http://python.org/ftp/python/2.7.5/python-2.7.5.msi)
 * Download the file
 * Press the start button, select run, and run cmd.exe
-* In the command shell, run these commands
+* In the command shell, create a virtual environment (recommended):
 
+```cmd
+# Install virtualenv if needed
+pip install virtualenv
+
+# Create virtual environment
+python -m virtualenv venv
+
+# Activate virtual environment
+venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
 ```
-python distribute_setup.py
-easy_install pip
-pip install python-dateutil requests
-```
+
+> **Note:** Using a virtual environment keeps dependencies isolated and prevents conflicts with system packages. Always activate the venv before running the tool.
 
 * Download toggl_target from [here](https://github.com/epablosensei/toggl_timesheet/archive/master.zip)
 * Expand the downloaded zip file, copy `config.py-example` & paste it as `config.py` beside `run.py`

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -1,0 +1,44 @@
+# Sprint Backlog
+
+## Current Sprint
+Started: 2026-01-21
+Goal: Python 3 Migration Planning
+
+## In Progress
+<!-- Tasks currently being worked on -->
+
+## Backlog (Prioritized)
+
+### Python 3 Migration
+- [ ] **[TASK-001]** Complete roundup function implementation
+  - File: toggltime/toggltime.py:180
+  - Notes: TODO comment exists, function is incomplete
+
+- [ ] **[TASK-002]** Audit Python 2/3 compatibility issues
+  - Check print statements (need parentheses)
+  - Check urllib imports (urllib vs urllib.parse)
+  - Check string handling (unicode)
+
+- [ ] **[TASK-003]** Add `from __future__ import` statements
+  - print_function, division, unicode_literals
+
+- [ ] **[TASK-004]** Update requirements.txt for Python 3
+  - Verify all dependencies support Python 3
+
+### Code Quality
+- [ ] **[TASK-005]** Add proper error handling for API failures
+- [ ] **[TASK-006]** Add unit tests for core functionality
+- [ ] **[TASK-007]** Add type hints (after Python 3 migration)
+
+### Features
+- [ ] **[TASK-008]** Consider adding XLS export option
+  - Branch exists: feature/xls_print
+
+## Completed
+<!-- Completed tasks with dates -->
+- [x] **[CHORE-001]** Add Claude Code configuration
+  - Completed: 2026-01-21
+  - Branch: claudify-repo
+
+## Blocked
+<!-- Tasks waiting on external dependencies -->

--- a/agent-docs/README.md
+++ b/agent-docs/README.md
@@ -1,0 +1,24 @@
+# Agent Documentation
+
+This folder contains detailed documentation that Claude can reference for specific tasks.
+
+## How to Use
+
+When asking Claude to work on a specific area, reference the relevant doc:
+- "Read agent-docs/api-patterns.md before implementing the new endpoint"
+- "Follow the conventions in agent-docs/python3-migration.md"
+
+## Suggested Documents
+
+Consider creating docs for:
+- **toggl-api.md** - Toggl API documentation, rate limits, authentication
+- **python3-migration.md** - Migration checklist, compatibility notes
+- **csv-format.md** - Expected CSV output format, column definitions
+- **time-rounding.md** - Business rules for time rounding and alignment
+
+## Tips
+
+- Keep each doc focused on one topic
+- Include concrete examples, not just abstract rules
+- Update docs when patterns change
+- Reference these docs in CLAUDE.md when relevant


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md with project overview, commands, architecture, and conventions
- Adds .claude/ settings for Claude Code configuration
- Documents virtualenv setup in README

## Note
This PR may show conflicts with develop in timesheet.py and requirements.txt.
These will be resolved when master is merged into develop (develop's versions will be kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)