### PR TITLE
feat: add --monthly flag and fix DATA_DIR handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ CLI tool to export Toggl time entries to CSV timesheets. Fetches time tracking d
 - `python timesheet.py -s 2024-01-01 -e 2024-01-31` - Custom date range
 - `python timesheet.py -p` - Generate per-project CSVs
 - `python timesheet.py -f` - Export all entries to full.csv
+- `python timesheet.py -m` - Generate monthly summary CSV per user (daily totals)
 - `python timesheet.py -h` - Show help
 
 ### Development Setup (using virtualenv - recommended)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ usage:  timeheet.py [OPTION...]
      -e,         --end=YYYY-MM-DD        End of the report - default: end of last month
      -p,         --per-project           create separate CSVs per project under each client
      -f,         --full                  export all entries to a single full.csv file
+     -m,         --monthly               export daily summary per user to monthly CSV
 
+-f exports every individual time entry (raw data) to a single CSV
+-m exports one row per day per user (daily totals across all clients/projects)
 
 ROUNDUP = 15  -> :00 :15 :30 :45; ROUNDUP = 30  -> :00 :30; ROUNDUP= 1  -> :00, 0 -> don't round up
 ALIGN = 15  -> :00 :15 :30 :45; ALIGN = 30  -> :00 :30; ALIGN= 1  -> :00, 0 -> don't round up

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -40,6 +40,12 @@ Goal: Python 3 Migration Planning
 
 ## Completed
 <!-- Completed tasks with dates -->
+- [x] **[TASK-010]** Add --monthly flag for daily summary per user
+  - Completed: 2026-02-08
+  - Branch: feature/monthly-timesheet
+  - Inspired by PR #14 (katalyst666), implemented as new flag instead of changing --full
+  - Produces one CSV per user: `{YYYY-MM}-{user}-monthly.csv`
+
 - [x] **[TASK-009]** Containerize for Podman/Docker (Python 2.7)
   - Completed: 2026-02-08
   - Branch: feature/podman-container

--- a/run-timesheet.sh
+++ b/run-timesheet.sh
@@ -20,14 +20,29 @@ if ! "$RUNTIME" image exists "$IMAGE" 2>/dev/null; then
     "$RUNTIME" build -t "$IMAGE" .
 fi
 
-# Set up mounts (:z needed for SELinux on Fedora/RHEL)
-MOUNTS="-v ./data:/app/data:z"
+# Determine host data directory
+# Priority: TOGGL_DATA_DIR env var > config.py DATA_DIR > default 'data'
+if [ -n "$TOGGL_DATA_DIR" ]; then
+    DATA_DIR="$TOGGL_DATA_DIR"
+elif [ -f config.py ]; then
+    DATA_DIR=$(python3 -c "
+import re
+for line in open('config.py'):
+    m = re.match(r\"DATA_DIR\s*=\s*['\x22](.+?)['\x22]\", line)
+    if m: print(m.group(1)); break
+else: print('data')
+" 2>/dev/null || echo "data")
+else
+    DATA_DIR="data"
+fi
+
+mkdir -p "$DATA_DIR"
+
+# Mount host DATA_DIR to same path inside container (:z for SELinux)
+MOUNTS="-v ./$DATA_DIR:/app/$DATA_DIR:z"
 
 if [ -f config.py ]; then
     MOUNTS="$MOUNTS -v ./config.py:/app/config.py:ro,z"
 fi
 
-# Create data directory if it doesn't exist
-mkdir -p data
-
-exec $RUNTIME run --rm $MOUNTS "$IMAGE" "$@"
+exec $RUNTIME run --rm -e TOGGL_DATA_DIR="$DATA_DIR" $MOUNTS "$IMAGE" "$@"

--- a/timesheet.py
+++ b/timesheet.py
@@ -80,8 +80,11 @@ def usage(error_msg=''):
     print "     -e,         --end=YYYY-MM-DD        End of the report - default: end of last month"
     print "     -p,         --per-project           create separate CSVs per project under each client"
     print "     -f,         --full                  export all entries to a single full.csv file"
+    print "     -m,         --monthly               export daily summary per user to monthly CSV"
 
     print ""
+    print "-f exports every individual time entry (raw data) to a single CSV"
+    print "-m exports one row per day per user (daily totals across all clients/projects)"
     print ""
     print "ROUNDUP = 15  -> :00 :15 :30 :45; ROUNDUP = 30  -> :00 :30; ROUNDUP= 1  -> :00, 0 -> don't round up"
     print "ALIGN = 15  -> :00 :15 :30 :45; ALIGN = 30  -> :00 :30; ALIGN= 1  -> :00, 0 -> don't round up"
@@ -101,12 +104,13 @@ def main():
     stop = False
     per_project = False
     full = False
+    monthly = False
 
     try:
         opts, args = getopt.gnu_getopt(
-            sys.argv[1:], "hd:r:a:t:z:w:s:e:pf",
+            sys.argv[1:], "hd:r:a:t:z:w:s:e:pfm",
             ["help", "api-token=", "data-dir=", "roundup=", "align-time=", "time-zone=", \
-             "workspace-id=", "start=", "end=", "per-project", "full"])
+             "workspace-id=", "start=", "end=", "per-project", "full", "monthly"])
     except getopt.GetoptError, e:
         usage(e.msg)
 
@@ -134,6 +138,8 @@ def main():
             per_project = True
         elif o == "-f" or o == "--full":
             full = True
+        elif o == "-m" or o == "--monthly":
+            monthly = True
 
     if not start and not stop:
         start = timelib.last_month_start()
@@ -194,7 +200,7 @@ def main():
     users = db.query('SELECT DISTINCT(user) FROM timesheet;')
 
     # Get the list of clients
-    if not full and not per_project:
+    if not full and not per_project and not monthly:
         clients = db.query('select distinct(client) from timesheet;')
 
         for c in clients:
@@ -267,6 +273,32 @@ def main():
             for entry in full_entries:
                 writer.writerow((entry['user'], entry['start'], entry['start_time'], entry['stop'], entry['stop_time'], entry['duration_dec']))
 
+    if monthly:
+        user_list = list(db.query('SELECT DISTINCT(user) FROM timesheet;'))
+        for u in user_list:
+            user_name = str(u['user'] or 'Unknown')
+            user_nameCC = user_name.replace(" ", "_").lower()
+
+            monthly_entries = db.query(
+                "SELECT user, start, MIN(start_time) AS start_time, "
+                "MAX(stop_time) AS stop_time, SUM(duration_dec) AS duration_dec "
+                "FROM timesheet WHERE user = :user "
+                "GROUP BY start ORDER BY start;",
+                {'user': user_name}
+            )
+
+            filename = "{}-{}-monthly.csv".format(
+                timelib.year_month_only(start), user_nameCC)
+            filepath = os.path.join(config.DATA_DIR, filename)
+            with open(filepath, 'w') as f:
+                print "Writing " + filepath
+                writer = csv.writer(f, delimiter=';', quoting=csv.QUOTE_NONNUMERIC)
+                writer.writerow(("User:", user_name))
+                writer.writerow(("Period:", "%s - %s" % (start.date(), stop.date())))
+                writer.writerow((""))
+                writer.writerow(("consultant", "start date", "start time", "stop time", "duration_dec"))
+                for entry in monthly_entries:
+                    writer.writerow((entry['user'], entry['start'], entry['start_time'], entry['stop_time'], entry['duration_dec']))
 
 
 def print_config():


### PR DESCRIPTION
## Summary

- Add `-m`/`--monthly` flag that exports a daily-aggregated monthly timesheet per user
- Each user gets their own CSV: `{YYYY-MM}-{user}-monthly.csv`
- Aggregates per day: `MIN(start_time)`, `MAX(stop_time)`, `SUM(duration_dec)`
- Keeps `--full` unchanged (raw data export with every individual time entry)
- Inspired by PR #14 (katalyst666) — extended the implementation into a new flag
- Fix `run-timesheet.sh` to detect `DATA_DIR` from `config.py` or `TOGGL_DATA_DIR` env var and mount the correct host directory

## Files

| File               | Action                                                    |
|--------------------|-----------------------------------------------------------|
| `timesheet.py`     | Modified — add `-m`/`--monthly` flag + CSV generation     |
| `run-timesheet.sh` | Modified — dynamic DATA_DIR detection, matching mount     |
| `README.md`        | Modified — add `-m` to usage docs                         |
| `CLAUDE.md`        | Modified — add monthly command example                    |
| `SPRINT.md`        | Modified — TASK-010 marked complete                       |

## Squash commit message

```
feat: add --monthly flag and fix DATA_DIR handling

Add -m/--monthly option that produces one CSV per user with daily
aggregated totals (MIN start_time, MAX stop_time, SUM duration).
Output: {YYYY-MM}-{user}-monthly.csv. Keeps --full unchanged as
raw data export.

Fix run-timesheet.sh to detect DATA_DIR from config.py or
TOGGL_DATA_DIR env var and mount the correct host directory
into the container.

Inspired by PR #14 (katalyst666). Closes #14.
```

## Test plan

- [x] `./run-timesheet.sh -h` — shows `-m`/`--monthly` with description
- [x] Help text explains difference between `-f` and `-m`
- [x] DATA_DIR detection extracts `data-new` from local config.py
- [x] Container resolves `DATA_DIR` to `data-new` with mounted config
- [x] `./run-timesheet.sh -m` — produces `{YYYY-MM}-{user}-monthly.csv` in `data-new/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)